### PR TITLE
Named directory for manual installation on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ this repo into your `~/.vim/bundle` directory and you are ready to go.
 
 ### Manual Installation
 
-Copy content into your `~/.vim` directory.
+Copy content into your `~/.vim` directory (or `%HOME%\vimfiles` on Windows).
 
 Be sure that the following lines are in your
 `.vimrc`


### PR DESCRIPTION
Manual installation on Windows did have no effect when I put the files into the `%HOME%\.vim` directory. User-specific configuration seems to go into `%HOME%\vimfiles` instead. Just mentioning this in `README.md`.